### PR TITLE
[MINOR] Upgrade object-assign

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "eventuate-filter": "^3.0.0",
     "eventuate-map": "^1.0.1",
     "eventuate-reduce": "^1.0.0",
-    "object-assign": "~3.0.0",
+    "object-assign": "^4.1.0",
     "shallow-copy": "0.0.1"
   },
   "scripts": {


### PR DESCRIPTION
This PR updates `object-assign` to `4.1.0`, the latest version.
